### PR TITLE
Fixed typo storke-->stroke.

### DIFF
--- a/gwt-openlayers-client/src/main/java/org/gwtopenmaps/openlayers/client/style/SymbolizerLineImpl.java
+++ b/gwt-openlayers-client/src/main/java/org/gwtopenmaps/openlayers/client/style/SymbolizerLineImpl.java
@@ -31,7 +31,7 @@ public class SymbolizerLineImpl
     }-*/;
 
     public static native String getStrokeColor(JSObject self) /*-{
-        return self.storkeColor;
+        return self.strokeColor;
     }-*/;
 
     public static native void setStrokeOpacity(JSObject self, double opacity) /*-{
@@ -39,7 +39,7 @@ public class SymbolizerLineImpl
     }-*/;
 
     public static native double getStrokeOpacity(JSObject self) /*-{
-        return self.storkeOpacity;
+        return self.strokeOpacity;
     }-*/;
 
     public static native void setStrokeWidth(JSObject self, int width) /*-{
@@ -59,7 +59,7 @@ public class SymbolizerLineImpl
     }-*/;
 
     public static native String getLinecap(JSObject self) /*-{
-        return self.storkeLinecap;
+        return self.strokeLinecap;
     }-*/;
 
 


### PR DESCRIPTION
This was fixed in the old version at BitBucket, but is not in the new version at GitHub.
Original author was andypower nazzareno.sileno@geosdi.org
