### PR TITLE
zoomlevel, resolution and scale handling:

### DIFF
--- a/gwt-openlayers-client/src/main/java/org/gwtopenmaps/openlayers/client/layer/Layer.java
+++ b/gwt-openlayers-client/src/main/java/org/gwtopenmaps/openlayers/client/layer/Layer.java
@@ -30,6 +30,7 @@ import org.gwtopenmaps.openlayers.client.event.LayerLoadStartListener.LoadStartE
 import org.gwtopenmaps.openlayers.client.event.LayerVisibilityChangedListener;
 import org.gwtopenmaps.openlayers.client.event.LayerVisibilityChangedListener.VisibilityChangedEvent;
 import org.gwtopenmaps.openlayers.client.util.JSObject;
+import com.google.gwt.core.client.JsArrayMixed;
 
 /**
  *
@@ -248,6 +249,46 @@ public class Layer extends OpenLayersEObjectWrapper {
                 });
     }
 
+	/**
+	 * Gets the contents of the given {@link JsArrayMixed} as a double array.
+	 * @param o {@link JsArrayMixed}
+	 * @return double[] if the array is not null, else null
+	 */
+	private static double[] getDoubleArray(JsArrayMixed o)
+	{
+		if (o != null)
+		{
+			double[] a = new double[o.length()];
+			for (int i = 0; i < o.length(); i++)
+			{
+				a[i] = o.getNumber(i);
+			}
+			return a;
+		}
+		else
+		{
+			return null;
+		}
+	}
+
+	/**
+	 * Get the maximum zoomlevel for this layer.
+	 * @return maximum zoomlevel
+	 */
+	public int getMaxZoomLevel()
+	{
+		return getMinZoomLevel() + LayerImpl.getResolutions(this.getJSObject()).length() - 1;
+	}
+
+	/**
+	 * Get the minimum zoomlevel for this layer.
+	 * @return minimum zoomlevel
+	 */
+	public int getMinZoomLevel()
+	{
+		return (int) this.getJSObject().getPropertyAsDouble("zoomOffset");
+	}
+
     public double getResolutionForZoom(double zoom) {
         double result = -1;
         if (this.isBaseLayer()) {
@@ -255,6 +296,24 @@ public class Layer extends OpenLayersEObjectWrapper {
         }
         return result;
     }
+
+	/**
+	 * Get all resolutions for the layer.
+	 * @return resolutions
+	 */
+	public double[] getResolutions()
+	{
+		return getDoubleArray(LayerImpl.getResolutions(this.getJSObject()));
+	}
+
+	/**
+	 * Get all scales for the layer.
+	 * @return scales
+	 */
+	public double[] getScales()
+	{
+		return getDoubleArray(LayerImpl.getScales(this.getJSObject()));
+	}
 
     public Projection getProjection() {
         return Projection.narrowToProjection(LayerImpl.getProjection(

--- a/gwt-openlayers-client/src/main/java/org/gwtopenmaps/openlayers/client/layer/LayerImpl.java
+++ b/gwt-openlayers-client/src/main/java/org/gwtopenmaps/openlayers/client/layer/LayerImpl.java
@@ -18,6 +18,8 @@ package org.gwtopenmaps.openlayers.client.layer;
 
 import org.gwtopenmaps.openlayers.client.util.JSObject;
 
+import com.google.gwt.core.client.JsArrayMixed;
+
 /**
  *
  * @author Erdem Gunay Amr Alam - Refractions Research Edwin Commandeur - Atlis
@@ -117,6 +119,14 @@ class LayerImpl {
      return layer.getResolutionForZoom(zoom);
      }-*/;
 
+    public static native JsArrayMixed getResolutions(JSObject layer) /*-{
+		return layer.resolutions;
+	}-*/;
+
+	public static native JsArrayMixed getScales(JSObject layer)	/*-{
+		return layer.scales;
+	}-*/;
+    
     public static native JSObject getProjection(JSObject layer) /*-{
      return layer.projection;
      }-*/;

--- a/gwt-openlayers-client/src/main/java/org/gwtopenmaps/openlayers/client/layer/XYZImpl.java
+++ b/gwt-openlayers-client/src/main/java/org/gwtopenmaps/openlayers/client/layer/XYZImpl.java
@@ -45,4 +45,17 @@ class XYZImpl
 
             return new $wnd.OpenLayers.Layer.XYZ(name, tmsURLs, layerParams);
     }-*/;
+    
+	/**
+	 * If your cache has more zoom levels than you want to provide access to with this layer, supply a zoomOffset. This
+	 * zoom offset is added to the current map zoom level to determine the level for a requested tile. For example, if
+	 * you supply a zoomOffset of 3, when the map is at the zoom 0, tiles will be requested from level 3 of your cache.
+	 * Default is 0 (assumes cache level and map zoom are equivalent). Using zoomOffset is an alternative to setting
+	 * serverResolutions if you only want to expose a subset of the server resolutions.
+	 * @param layer layer
+	 * @param zoomOffset zoom offset
+	 */
+   public static native void setZoomOffset(JSObject layer, int zoomOffset) /*-{
+	    layer["zoomOffset"] = zoomOffset;
+	}-*/;
 }


### PR DESCRIPTION
Added getters for resolution and scales to Layer (http://dev.openlayers.org/apidocs/files/OpenLayers/Layer-js.html).
XYZ layer can get an offset for zoomlevels and a range of zoomlevels can be set.
This allows to use XYZ sources, which do not contain all zoomlevels or should be limited and corresponds with http://dev.openlayers.org/apidocs/files/OpenLayers/Layer/XYZ-js.html.
