### PR TITLE
Do not fail to compile using GWT xsiframe linker

### DIFF
--- a/gwt-openlayers-client/src/main/java/org/gwtopenmaps/openlayers/OpenLayers.gwt.xml
+++ b/gwt-openlayers-client/src/main/java/org/gwtopenmaps/openlayers/OpenLayers.gwt.xml
@@ -19,4 +19,6 @@
 <module>
     <inherits name='com.google.gwt.user.User'/>
     <script src="js/gwt-openlayers/util.js"></script>
+    <!-- Do not fail to compile using GWT xsiframe linker. -->
+    <set-configuration-property name='xsiframe.failIfScriptTag' value='FALSE'/>
 </module>


### PR DESCRIPTION
Do not fail to compile using GWT xsiframe linker, addressing the following error:

```
   Invoking Linker Cross-Site-Iframe
      [ERROR] The Cross-Site-Iframe linker does not support <script> tags in the gwt.xml files, but the gwt.xml file (or the gwt.xml files which it includes) contains the following script tags:
js/gwt-openlayers/util.js
In order for your application to run correctly, you will need to include these tags in your host page directly. In order to avoid this error, you will need to remove the script tags from the gwt.xml file, or add this property to the gwt.xml file: <set-configuration-property name='xsiframe.failIfScriptTag' value='FALSE'/>
```

Using the xsiframe linker to compile is necessary for using GWT Super Dev Mode (http://www.gwtproject.org/articles/superdevmode.html), which is going to replace the old Dev Mode based on plugins (see https://docs.google.com/presentation/d/1DTWZ_06dQsTPhinIwzHSdoPMndRr92wpZoZWicK97YQ/edit#slide=id.g29754e903_00).
NOTE: There are no side-effects for existing projects, the patch just enables users of the xsiframe linker to compile their projects.

Users linking using the xsiframe linker need to include a script tag referring to "MODULE/js/gwt-openlayers/util.js" in the host page (MODULE is a placeholder for the name of the users GWT module):

```
    <!-- load GWT OpenLayers -->
    <script type="text/javascript" src="MODULE/js/gwt-openlayers/util.js"></script>
```
