### PR TITLE
Try to return instances of Geometry subclasses where possible instead of a generic Geometry instance.

### DIFF
--- a/gwt-openlayers-client/src/main/java/org/gwtopenmaps/openlayers/client/feature/VectorFeature.java
+++ b/gwt-openlayers-client/src/main/java/org/gwtopenmaps/openlayers/client/feature/VectorFeature.java
@@ -85,8 +85,8 @@ public class VectorFeature extends Feature {
      * <code>
      * VectorFeature vf = wkt.read("POINT (1 2)");
      * Geometry g = vf.getGeometry();
-     * if(g.getClassName().equals(Geometry.POINT_CLASS_NAME){
-     *   Point p = Point.narrowToPoint(g.getJSObject());
+     * if(g instanceof Point){
+     *   Point p = (Point)g;
      * };
      * </code>
      */

--- a/gwt-openlayers-client/src/main/java/org/gwtopenmaps/openlayers/client/geometry/Geometry.java
+++ b/gwt-openlayers-client/src/main/java/org/gwtopenmaps/openlayers/client/geometry/Geometry.java
@@ -17,10 +17,8 @@
 package org.gwtopenmaps.openlayers.client.geometry;
 
 import com.google.gwt.core.client.JsArray;
-import org.gwtopenmaps.openlayers.client.Bounds;
-import org.gwtopenmaps.openlayers.client.LonLat;
-import org.gwtopenmaps.openlayers.client.OpenLayersObjectWrapper;
-import org.gwtopenmaps.openlayers.client.Projection;
+
+import org.gwtopenmaps.openlayers.client.*;
 import org.gwtopenmaps.openlayers.client.util.JSObject;
 
 /**
@@ -130,7 +128,52 @@ public class Geometry extends OpenLayersObjectWrapper {
     }
 
     public static Geometry narrowToGeometry(JSObject element) {
-        return (element == null) ? null : new Geometry(element);
+		// return null on null
+		if (element == null)
+		{
+			return null;
+		}
+		// try to return an instance of the concrete GWT class instead of a generic Geometry instance
+		// this will allow callers to directly use the returned instance without allocating another instance 
+		// of a GWT class
+		String className = OpenLayersObjectWrapper.narrowToOpenLayersObjectWrapper(element).getClassName();
+		if (className != null)
+		{
+			if (className.equals(Geometry.CURVE_CLASS_NAME))
+			{
+				return Curve.narrowToCurve(element);
+			}
+			else if (className.equals(Geometry.LINEARRING_CLASS_NAME))
+			{
+				return LinearRing.narrowToLinearRing(element);
+			}
+			else if (className.equals(Geometry.LINESTRING_CLASS_NAME))
+			{
+				return LineString.narrowToLineString(element);
+			}
+			else if (className.equals(Geometry.MULTI_LINE_STRING_CLASS_NAME))
+			{
+				return MultiLineString.narrowToMultiLineString(element);
+			}
+			else if (className.equals(Geometry.MULTI_POINT_CLASS_NAME))
+			{
+				return MultiPoint.narrowToMultiPoint(element);
+			}
+			else if (className.equals(Geometry.MULTI_POLYGON_CLASS_NAME))
+			{
+				return MultiPolygon.narrowToMultiPolygon(element);
+			}
+			else if (className.equals(Geometry.POINT_CLASS_NAME))
+			{
+				return Point.narrowToPoint(element);
+			}
+			else if (className.equals(Geometry.POLYGON_CLASS_NAME))
+			{
+				return Polygon.narrowToPolygon(element);
+			}
+		}
+		// default case returns a Geometry object wrapping the element
+		return new Geometry(element);
     }
 
     public static Geometry fromWKT(String wkt) {


### PR DESCRIPTION
This will  this will allow callers to directly use the returned instance without allocating another instance of a Geometry class from the JS object.
For all non-recognized geometries and null geometries the behavior of narrowToGeometry is left unchanged, only known subclasses of Geometry are turned into their respective GWT object representations.
