### PR TITLE
Fixed "setGutter" in LayerOptions

### DIFF
--- a/gwt-openlayers-client/src/main/java/org/gwtopenmaps/openlayers/client/layer/LayerOptions.java
+++ b/gwt-openlayers-client/src/main/java/org/gwtopenmaps/openlayers/client/layer/LayerOptions.java
@@ -148,7 +148,7 @@ public class LayerOptions extends JSObjectWrapper {
      * Defaults to zero. Non-tiled layers always have zero gutter."
      */
     public void setGutter(float gutter) {
-        getJSObject().setProperty("alwaysInRange", gutter);
+        getJSObject().setProperty("gutter", gutter);
     }
 
     /**


### PR DESCRIPTION
In method "setGutter" the property name "alwaysInRange" was used instead of "gutter"