### PR TITLE
Changed transition.toString() to transition.getValue()

### DIFF
--- a/gwt-openlayers-client/src/main/java/org/gwtopenmaps/openlayers/client/layer/LayerOptions.java
+++ b/gwt-openlayers-client/src/main/java/org/gwtopenmaps/openlayers/client/layer/LayerOptions.java
@@ -273,7 +273,7 @@ public class LayerOptions extends JSObjectWrapper {
     }
 
     public void setTransitionEffect(TransitionEffect transition) {
-        getJSObject().setProperty("transitionEffect", transition.toString());
+        getJSObject().setProperty("transitionEffect", transition.getValue());
     }
 
     /**


### PR DESCRIPTION
Method "void setTransitionEffect(TransitionEffect transition)" was using enum with toString() that returned the enum's name instead of the desierd value. Changed it to getValue() for intended behaviour.